### PR TITLE
refactor: Remove zkpok verification and signing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5739,23 +5739,6 @@
         "inherits": "^2.0.1"
       }
     },
-    "node_modules/rollup": {
-      "version": "3.24.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.24.0.tgz",
-      "integrity": "sha512-OgraHOIg2YpHQTjl0/ymWfFNBEyPucB7lmhXrQUh38qNOegxLapSPFs9sNr0qKR75awW41D93XafoR2QfhBdUQ==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=14.18.0",
-        "npm": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
     "node_modules/rollup-plugin-copy": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-copy/-/rollup-plugin-copy-3.5.0.tgz",
@@ -6442,20 +6425,6 @@
       "integrity": "sha512-hyVbaCUd18UiXk656g/imaBLMogpdijIEpnhWYrSda9rhvO4gOU16n2nh7xG5lv/rjumnZzGOdz0CEGTmFe0fQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=12.20"
-      }
     },
     "node_modules/universalify": {
       "version": "0.1.2",
@@ -7961,8 +7930,7 @@
       "version": "6.1.3",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-wasm/-/plugin-wasm-6.1.3.tgz",
       "integrity": "sha512-7ItTTeyauE6lwdDtQWceEHZ9+txbi4RRy0mYPFn9BW7rD7YdgBDu7HTHsLtHrRzJc313RM/1m6GKgV3np/aEaw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@rollup/pluginutils": {
       "version": "5.1.2",
@@ -8383,22 +8351,19 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.1.0.tgz",
       "integrity": "sha512-K/vuv72vpfSEZoo5KIU0a2FsEoYdW0DUMtMpB5X3LlUwshetMZRZRxB7sCsVji/lFaSxtQQ3aM9O4eMolXkU9w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@webpack-cli/info": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.1.tgz",
       "integrity": "sha512-fE1UEWTwsAxRhrJNikE7v4EotYflkEhBL7EbajfkPlf6E37/2QshOy/D48Mw8G5XMFlQtS6YV42vtbG9zBpIQA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@webpack-cli/serve": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.4.tgz",
       "integrity": "sha512-0xRgjgDLdz6G7+vvDLlaRpFatJaJ69uTalZLRSMX5B3VUrDmXcrVA3+6fXXQgmYz7bY9AAgs348XQdmtLsK41A==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -8422,8 +8387,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
       "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "aes-js": {
       "version": "4.0.0-beta.5",
@@ -8447,8 +8411,7 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -10302,8 +10265,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-raw-loader": {
       "version": "1.0.1",
@@ -11212,16 +11174,6 @@
         "inherits": "^2.0.1"
       }
     },
-    "rollup": {
-      "version": "3.24.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.24.0.tgz",
-      "integrity": "sha512-OgraHOIg2YpHQTjl0/ymWfFNBEyPucB7lmhXrQUh38qNOegxLapSPFs9sNr0qKR75awW41D93XafoR2QfhBdUQ==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "fsevents": "~2.3.2"
-      }
-    },
     "rollup-plugin-copy": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-copy/-/rollup-plugin-copy-3.5.0.tgz",
@@ -11708,13 +11660,6 @@
       "integrity": "sha512-hyVbaCUd18UiXk656g/imaBLMogpdijIEpnhWYrSda9rhvO4gOU16n2nh7xG5lv/rjumnZzGOdz0CEGTmFe0fQ==",
       "dev": true
     },
-    "typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
-      "dev": true,
-      "peer": true
-    },
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -11983,8 +11928,7 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
       "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "y18n": {
       "version": "5.0.8",

--- a/src/sdk/encrypt.ts
+++ b/src/sdk/encrypt.ts
@@ -43,6 +43,7 @@ export type ZKInput = {
   getBits: () => number[];
   encrypt: () => Promise<{
     prehandle: Uint8Array;
+    ciphertext: Uint8Array;
   }>;
 };
 
@@ -264,8 +265,9 @@ export const createEncryptedInput =
           .digest();
 
         return {
-          // This fork of fhevmjs only supports one prehandle
+          // This fork of fhevmjs only supports one prehandle and ciphertext at a time.
           prehandle,
+          ciphertext,
         };
       },
     };

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -1,7 +1,6 @@
 import {
   FhevmInstanceConfig,
   getChainId,
-  getKMSSignatures,
   getProvider,
   getPublicParams,
   getTfheCompactPublicKey,
@@ -66,8 +65,6 @@ export const createInstance = async (
 
   const pkePublicParams: PublicParams = await getPublicParams(config);
 
-  const kmsSignatures = await getKMSSignatures(provider, config);
-
   return {
     createEncryptedInput: createEncryptedInput(
       aclContractAddress,
@@ -79,7 +76,7 @@ export const createInstance = async (
     generateKeypair,
     createEIP712: createEIP712(chainId),
     reencrypt: reencryptRequest(
-      kmsSignatures,
+      [],
       chainId,
       kmsContractAddress,
       cleanURL(config.gatewayUrl),


### PR DESCRIPTION
**IMPORTANT: This PR is really focused for the investors demo.**

This PR is a fork of Zama's fhevmjs@v0.6.0-4, that does the following things:
- Zama sends their zkpok to the gateway for verfication. We remove that part
- Zama has a function to get the KMS signers at startup, we remove that.

Since it's focused on the investors demo, it's NOT REQUIRED to merge this PR. Currently, the [investors demo script](https://github.com/Inco-fhevm/investors-demo.js) simply uses this branch as a git submodule, and imports code directly from the branch.